### PR TITLE
Fixed scrolling, added several methods

### DIFF
--- a/selenium_scraper/mapping.py
+++ b/selenium_scraper/mapping.py
@@ -1,0 +1,5 @@
+class ScrollMethods:
+    """ Available ways to scroll the page down """
+    js_instant = 'js_instant'
+    js_smooth = 'js_smooth'
+    end_key = 'end_key'

--- a/tests/test_scroll.py
+++ b/tests/test_scroll.py
@@ -1,10 +1,44 @@
+import pytest
+from selenium_scraper.mapping import ScrollMethods
 
-def test_scroll_infinite_page(scraper, base_url):
-    """ Checks for scrolling down an infinite page """
+
+def test_scroll_infinite_page_end_key(scraper, base_url):
+    """ Checks for scrolling down an infinite page with `end_key` method """
     n_scrolls = 5
 
     scraper.get(base_url + '/infinite_page')
-    scraper.scroll_down(n_scrolls, 2)
+    scraper.scroll_infinite_page(n_scrolls, 2, ScrollMethods.end_key)
 
     paragraphs = scraper.current_page.find_all('div', {'class': 'paragraph'})
     assert len(paragraphs) - 1 == n_scrolls
+
+
+def test_scroll_infinite_page_js_instant(scraper, base_url):
+    """ Checks for scrolling down an infinite page with `js_instant` method """
+    n_scrolls = 5
+
+    scraper.get(base_url + '/infinite_page')
+    scraper.scroll_infinite_page(n_scrolls, 2, ScrollMethods.js_instant)
+
+    paragraphs = scraper.current_page.find_all('div', {'class': 'paragraph'})
+    assert len(paragraphs) - 1 == n_scrolls
+
+
+def test_scroll_infinite_page_js_smooth(scraper, base_url):
+    """ Checks for scrolling down an infinite page with `js_smooth` method """
+    n_scrolls = 5
+
+    scraper.get(base_url + '/infinite_page')
+    scraper.scroll_infinite_page(n_scrolls, 2, ScrollMethods.js_smooth)
+
+    paragraphs = scraper.current_page.find_all('div', {'class': 'paragraph'})
+    assert len(paragraphs) - 1 == n_scrolls
+
+
+def test_scroll_infinite_page_wrong_method(scraper, base_url):
+    """ Checks for scrolling down an infinite page with wrong method """
+    n_scrolls = 5
+
+    scraper.get(base_url + '/infinite_page')
+    with pytest.raises(ValueError):
+        scraper.scroll_infinite_page(n_scrolls, 2, 'my_method')


### PR DESCRIPTION
Issue #16: Content not loading when scrolling down on some pages

Split the `BaseScraper.scroll_down` method into two:

1. `BaseScraper.scroll_down` - to scroll the page 1 time
2. `BaseScraper.scroll_infinite_page` - to scroll the endless page several times

For each method, you can select the scrolling way specified in `selenium_scraper.mapping.ScrollMethods`
- **ScrollMethods.js_instant**: using javascript window.scrollTo with 'behavior: "instant"'.
This method scrolls the page immediately (as if teleporting us to the bottom of the page).
Pros: Highest speed.
Cons: Triggers for loading new content may not work on some pages.

- **ScrollMethods.js_smooth**: using javascript window.scrollTo with 'behavior: "smooth"'.
The problem of teleportation of the previous method is solved. Slower movement

- **ScrollMethods.end_key**: holding down the End key.
As in the previous method, the movement is smooth.
Most often 'js_smooth' and 'end_key' should be the same, but in case of some inaccuracies on some pages,
you can try to replace them.